### PR TITLE
Bring the mapzen-geocoder circle back 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developed by [Ilya Ilyankou](https://github.com/ilyankou) and [Jack Dougherty](h
 - Leaflet v1.0.3 https://leafletjs.com (BSD-2-Clause)
 - jQuery v3.2.0 https://code.jquery.com (MIT)
 - leaflet-providers (v1.1.15, manually updated for Carto https) https://github.com/leaflet-extras/leaflet-providers (BSD-2-Clause)
-- Mapzen Search geocoding plugin (v1.8.1) https://github.com/mapzen/leaflet-geocoder (MIT)
+- Mapzen Search geocoding plugin (v1.8.1, customized to display a blue circle around the search result) https://github.com/mapzen/leaflet-geocoder (MIT)
 - leaflet-locatecontrol (v0.60.0) https://github.com/domoritz/leaflet-locatecontrol (MIT)
 - Leaflet.markercluster (v1.0.4) https://github.com/Leaflet/Leaflet.markercluster (MIT)
 - Leaflet.MarkerCluster.LayerSupport (v.1.0.3) https://github.com/ghybs/Leaflet.MarkerCluster.LayerSupport (MIT)

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
   <script type="text/javascript" src="https://unpkg.com/leaflet.markercluster@1.0.4/dist/leaflet.markercluster.js"></script>
 
   <!-- Mapzen Search -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.8.1/leaflet-geocoder-mapzen.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-geocoder-mapzen/1.8.1/leaflet-geocoder-mapzen.js"></script>
+  <link rel="stylesheet" href="scripts/leaflet-geocoder/leaflet-geocoder-mapzen.css">
+  <script src="scripts/leaflet-geocoder/leaflet-geocoder-mapzen.js"></script>
 
   <!-- Locate Control -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.60.0/L.Control.Locate.min.css" />


### PR DESCRIPTION
Fixes #9 
Partly resolves #11 - it now makes sure that polygons, points and polylines are fully processed before hiding the css loader and showing the actual map. Speed is still slow with the table on. I will dive into it.