### PR TITLE
Extend displayTitle to include topcenter

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -969,12 +969,11 @@ $(window).on('load', function() {
       var title = '<h3 class="pointer">' + getSetting('_mapTitle') + '</h3>';
       var subtitle = '<h5>' + getSetting('_mapSubtitle') + '</h5>';
 
-      if (dispTitle == 'on') {
+      if (dispTitle == 'topleft') {
         $('div.leaflet-top').prepend('<div class="map-title leaflet-bar leaflet-control leaflet-control-custom">' + title + subtitle + '</div>');
-      } else if (dispTitle == 'in points legend') {
-        $('#points-legend').prepend(title + subtitle);
-      } else if (dispTitle == 'in polygons legend') {
-        $('.polygons-legend').prepend(title + subtitle);
+      } else if (dispTitle == 'topcenter') {
+        $('#map').append('<div class="div-center"></div>');
+        $('.div-center').append('<div class="map-title leaflet-bar leaflet-control leaflet-control-custom">' + title + subtitle + '</div>');
       }
 
       $('.map-title h3').click(function() { location.reload(); });

--- a/style.css
+++ b/style.css
@@ -251,3 +251,12 @@ select {
   font-size: 1.2em;
   font-weight: bold;
 }
+
+.div-center {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  padding-top: 10px;
+}


### PR DESCRIPTION
* Display Title can now be set to `topleft`, `topcenter`, and `off`.

![screen shot 2017-04-09 at 20 58 43](https://cloud.githubusercontent.com/assets/10443203/24837855/831576ec-1d67-11e7-8153-9cc2ac274219.png)

Resolves #17 