### PR TITLE
Significant improvements

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -21,8 +21,6 @@ var constants = {
   _initZoom: 'Initial Zoom',
   _initLat: 'Initial Center Latitude',
   _initLon: 'Initial Center Longitude',
-  _displayAllPolygons: 'Display Polygons Simultaneously',
-  _displayCommasInNumbers: 'Display Commas in Numbers',
 	// Map Controls
 	_mapSearch: 'Search Button',
   _mapSearchKey: 'Mapzen Search Key',
@@ -34,6 +32,7 @@ var constants = {
 	// Point Map Display
 	_pointsLegendTitle: 'Point Legend Title',
 	_pointsLegendPos: 'Point Legend Position',
+  _pointsLegendIcon: 'Point Legend Icon',
   // Table Map
   _displayTable: 'Display Table',
   _tableHeight: 'Table Height',
@@ -42,11 +41,12 @@ var constants = {
   // Polyline Map Controls
   _polylinesLegendTitle: 'Polyline Legend Title',
   _polylinesLegendPos: 'Polyline Legend Position',
+  _polylinesLegendIcon: 'Polyline Legend Icon',
   _polylinesWeight: 'Polyline Thickness',
 	// Polygon Map Display
 	_polygonsLegendTitle: 'Polygon Legend Title',
 	_polygonsLegendPosition: 'Polygon Legend Position',
-  _polygonsGeojsonName: 'Polygon GeoJSON Name',
+  _polygonsLegendIcon: 'Polygon Legend Icon',
   _polygonsGeojsonURL: 'Polygon GeoJSON URL',
   _popupProp: 'Property Popups, Labels',
   _polygonLayers: 'Polygon Properties, Labels',
@@ -58,4 +58,5 @@ var constants = {
   _polygonDisplayImages: 'Show Images When Available',
   _polygonLabel: 'Show Polygon Labels',
   _polygonLabelZoomLevel: 'Show Polygon Labels at Zoom Level',
+  _polygonShowOnStart: 'Show Polygon Data on Start',
 };

--- a/style.css
+++ b/style.css
@@ -28,10 +28,6 @@ h6 {
   font-size: 1.2em;
 }
 
-.leaflet-top .map-title {
-  max-width: 450px;
-}
-
 .intro-popup .leaflet-popup-tip-container {
   width: 0;
   height: 0;
@@ -218,14 +214,14 @@ form {
   vertical-align: middle;
 }
 
-.polygons-legend-merged {
-  width: 160px;
-  overflow: hidden;
-  margin-top: 0px !important;
+.map-title {
+  margin-top: 0 !important;
+  margin-bottom: 10px;
+  max-width: 450px;
 }
 
-.polygons-legend0 {
-  margin-top: 10px !important;
+.leaflet-top.leaflet-left {
+  padding-top: 10px;
 }
 
 /* Map Table */
@@ -259,4 +255,31 @@ select {
   justify-content: center;
   align-items: center;
   padding-top: 10px;
+}
+
+span.legend-arrow {
+  color: rgb(238, 238, 238);
+  position: absolute;
+  right: 8px;
+  top: 5px;
+}
+
+span.legend-icon {
+  color: #bbb;
+  margin-right: 5px;
+}
+
+.ladder {
+  width: 180px;
+  margin-top: 0 !important;
+  overflow: hidden;
+}
+
+.ladder h6.minimize ~ div,
+.ladder h6.minimize ~ form {
+  display: none !important;
+}
+
+.ladder form, .ladder div {
+  display: block;
 }


### PR DESCRIPTION
Jack, I implemented all of the changes mentioned in #21:
* Numbers use commas by default
* `GeoJSON Name` is removed
* `Display Polygons Simultaneously` option is removed. Right now all polygons that map.js can find are added to the map. Their legends are stacked up in the top left corner. Only those polygons whose `Show Polygon Data on Start` is `on` are displayed.
* I managed to remove significant chunks of polygon processing code, but further optimization can be performed.
* All controls are of the same width (180px) and stacked together. Only one legend can be unrolled (the rest are minimized). The first legend in the map is unrolled by default.
* `Polygon/Polyline/Point Legend Icon` option is added. It is a Font-Awesome icon that is displayed to the left of the map title. It could be omitted.
* Up/down arrows are added to each legend to hint that those can be unrolled.

![screen shot 2017-04-10 at 14 53 23](https://cloud.githubusercontent.com/assets/10443203/24851762/1f72b800-1dff-11e7-9446-47fb9dcdc328.png)
